### PR TITLE
Compatibility with Swift 2.0

### DIFF
--- a/Observable-Swift.xcodeproj/project.pbxproj
+++ b/Observable-Swift.xcodeproj/project.pbxproj
@@ -352,7 +352,8 @@
 		65263A941954BC5000B39269 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Leszek Ślażyński";
 				TargetAttributes = {
 					65263A9C1954BC5000B39269 = {
@@ -562,6 +563,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -634,6 +636,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Observable-Swift/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.utdloc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Observable;
 				SDKROOT = macosx;
 			};
@@ -647,6 +650,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Observable-Swift/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.utdloc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Observable;
 				SDKROOT = macosx;
 			};
@@ -662,6 +666,7 @@
 				);
 				INFOPLIST_FILE = "Observable-SwiftTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.utdloc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -677,6 +682,7 @@
 				);
 				INFOPLIST_FILE = "Observable-SwiftTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.utdloc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -691,6 +697,7 @@
 				INFOPLIST_FILE = "Observable-Swift/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.utdloc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Observable;
 				SDKROOT = iphoneos;
 			};
@@ -705,6 +712,7 @@
 				INFOPLIST_FILE = "Observable-Swift/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.utdloc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Observable;
 				SDKROOT = iphoneos;
 			};
@@ -719,6 +727,7 @@
 				);
 				INFOPLIST_FILE = "Observable-SwiftTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.utdloc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 			};
@@ -733,6 +742,7 @@
 				);
 				INFOPLIST_FILE = "Observable-SwiftTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.utdloc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 			};

--- a/Observable-Swift.xcodeproj/project.pbxproj
+++ b/Observable-Swift.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 		65263A941954BC5000B39269 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = "Leszek Ślażyński";
 				TargetAttributes = {
 					65263A9C1954BC5000B39269 = {
@@ -625,6 +625,7 @@
 		65263AB41954BC5000B39269 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Observable-Swift/Info.plist";
@@ -637,6 +638,7 @@
 		65263AB51954BC5000B39269 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Observable-Swift/Info.plist";
@@ -649,6 +651,7 @@
 		65263AB71954BC5000B39269 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
@@ -663,6 +666,7 @@
 		65263AB81954BC5000B39269 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",

--- a/Observable-Swift/Event.swift
+++ b/Observable-Swift/Event.swift
@@ -51,7 +51,7 @@ public struct Event<T>: UnownableEvent {
         _subscriptions.removeAll()
     }
     
-    public mutating func add(#owner : AnyObject, _ handler : HandlerType) -> SubscriptionType {
+    public mutating func add(owner owner : AnyObject, _ handler : HandlerType) -> SubscriptionType {
         return add(SubscriptionType(owner: owner, handler: handler))
     }
     

--- a/Observable-Swift/Event.swift
+++ b/Observable-Swift/Event.swift
@@ -31,7 +31,7 @@ public struct Event<T>: UnownableEvent {
     }
     
     public mutating func add(handler : HandlerType) -> SubscriptionType {
-        return add(SubscriptionType(owner: nil, handler))
+        return add(SubscriptionType(owner: nil, handler: handler))
     }
     
     public mutating func remove(subscription : SubscriptionType) {

--- a/Observable-Swift/EventReference.swift
+++ b/Observable-Swift/EventReference.swift
@@ -34,7 +34,7 @@ public class EventReference<T>: OwnableEvent {
         event.removeAll()
     }
     
-    public func add(#owner : AnyObject, _ handler : HandlerType) -> SubscriptionType {
+    public func add(owner owner : AnyObject, _ handler : HandlerType) -> SubscriptionType {
         return event.add(owner: owner, handler)
     }
     

--- a/Observable-Swift/Info.plist
+++ b/Observable-Swift/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.utdloc.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Observable-Swift/Observable.swift
+++ b/Observable-Swift/Observable.swift
@@ -31,7 +31,7 @@ public struct Observable<T> : UnownableObservable {
     didSet { afterChange.notify(ValueChange(oldValue, value)) }
     }
     
-    public mutating func unshare(#removeSubscriptions: Bool) {
+    public mutating func unshare(removeSubscriptions removeSubscriptions: Bool) {
         if removeSubscriptions {
             beforeChange = EventReference<ValueChange<T>>()
             afterChange = EventReference<ValueChange<T>>()

--- a/Observable-Swift/ObservableChainingProxy.swift
+++ b/Observable-Swift/ObservableChainingProxy.swift
@@ -56,11 +56,11 @@ public class ObservableChainingProxy<O1: AnyObservable, O2: AnyObservable>: Owna
         self.base = base
         self.path = path
 
-        var beforeSubscription = EventSubscription(owner: self) { [weak self] in
+        let beforeSubscription = EventSubscription(owner: self) { [weak self] in
             self!.beforeChange.notify(self!.targetChangeToValueChange($0))
         }
         
-        var afterSubscription = EventSubscription(owner: self) { [weak self] in
+        let afterSubscription = EventSubscription(owner: self) { [weak self] in
             self!.afterChange.notify(self!.targetChangeToValueChange($0))
         }
         

--- a/Observable-Swift/ObservableChainingProxy.swift
+++ b/Observable-Swift/ObservableChainingProxy.swift
@@ -118,7 +118,7 @@ public func chain<O: AnyObservable>(o: O) -> ObservableChainingBase<O> {
 }
 
 public func / <O1: AnyObservable, O2: AnyObservable, O3: AnyObservable> (o: ObservableChainingProxy<O1, O2>, f: O2.ValueType -> O3?) -> ObservableChainingProxy<ObservableChainingProxy<O1, O2>, O3> {
-    return o.to(f)
+    return o.to(path: f)
 }
 
 public func / <O1: AnyObservable, O2: AnyObservable> (o: O1, f: O1.ValueType -> O2?) -> ObservableChainingProxy<O1, O2> {

--- a/Observable-Swift/OwningEventReference.swift
+++ b/Observable-Swift/OwningEventReference.swift
@@ -41,7 +41,7 @@ public class OwningEventReference<T>: EventReference<T> {
         event.removeAll()
     }
     
-    public override func add(#owner : AnyObject, _ handler : HandlerType) -> SubscriptionType {
+    public override func add(owner owner : AnyObject, _ handler : HandlerType) -> SubscriptionType {
         let subscr = event.add(owner: owner, handler)
         if owned != nil {
             subscr.addOwnedObject(self)

--- a/Observable-Swift/Protocols.swift
+++ b/Observable-Swift/Protocols.swift
@@ -27,7 +27,7 @@ public protocol AnyEvent {
     mutating func removeAll()
     
     /// Create, add and return a subscription with given handler and owner.
-    mutating func add(#owner : AnyObject, _ handler : ValueType -> ()) -> EventSubscription<ValueType>
+    mutating func add(owner owner : AnyObject, _ handler : ValueType -> ()) -> EventSubscription<ValueType>
 
 }
 
@@ -64,7 +64,7 @@ public protocol WritableObservable : AnyObservable {
 /// Observable which is a value type. Elementary observables are value types.
 public protocol UnownableObservable : WritableObservable {
     /// Unshares events
-    mutating func unshare(#removeSubscriptions: Bool)
+    mutating func unshare(removeSubscriptions removeSubscriptions: Bool)
 }
 
 /// Observable which is a reference type. Compound observables are reference types.

--- a/Observable-SwiftTests/Info.plist
+++ b/Observable-SwiftTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.utdloc.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Observable-SwiftTests/ObservableTests.swift
+++ b/Observable-SwiftTests/ObservableTests.swift
@@ -108,7 +108,7 @@ class ObservableTests: XCTestCase {
     
     func testAddHandlerToOptional() {
         var original = Observable(0)
-        var optional = Optional.Some(original)
+        let optional = Optional.Some(original)
         
         var calledTimes = 0
         optional!.afterChange.add({ _ in calledTimes += 1 })
@@ -132,7 +132,7 @@ class ObservableTests: XCTestCase {
     }
     
     func testValueAfterCopy() {
-        var original = Observable(0)
+        let original = Observable(0)
         var copy = makeCopy(original)
         
         XCTAssertEqual(0, original^)
@@ -197,7 +197,7 @@ class ObservableTests: XCTestCase {
     
     func testTripleObserver() {
         var (title, first, last) = (Observable("Mr."), Observable("John"), Observable("Smith"))
-        var either3 = title & first & last
+        let either3 = title & first & last
         
         let getFull = { "\($0 as String) \($1 as String) \($2 as String)" }
         var full = getFull(title^, first^, last^)
@@ -356,7 +356,7 @@ class ObservableTests: XCTestCase {
         var x = Observable(0)
         var y = 0
 
-        var xr = proxy(x)
+        let xr = proxy(x)
         xr.afterChange += { (_,_) in y += 1 }
 
         for i in 0..<5 { x <- i }
@@ -487,10 +487,10 @@ class ObservableTests: XCTestCase {
             }
         }
         
-        var john = Person(first: "John", last: "Doe")
-        var ramsay = Person(first: "Ramsay", last: "Snow")
+        let john = Person(first: "John", last: "Doe")
+        let ramsay = Person(first: "Ramsay", last: "Snow")
         
-        var me = Person(first: "John", last: "Snow")
+        let me = Person(first: "John", last: "Snow")
         
         var name1 : String? = nil
         var name2 : String? = nil


### PR DESCRIPTION
Mostly resolves warnings related to unnecessary variable declarations (that are now changed to constants). Some syntax for named parameters has also changed.