### PR TITLE
Fix Carthage Build Failure

### DIFF
--- a/Observable-Swift.xcodeproj/xcshareddata/xcschemes/Observable-iOS.xcscheme
+++ b/Observable-Swift.xcodeproj/xcshareddata/xcschemes/Observable-iOS.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6592C3051957532100BA8CB7"


### PR DESCRIPTION
### Problem 
Carthage builds for iOS would fail because unit testing targets would build along with the framework target. However unit tests targets must be code signed as of iOS SDK 9.1.

"CodeSign error: code signing is required for product type 'Unit Test Bundle' in SDK 'iOS 9.1'"

### Solution
Prevent unit test targets from building with the framework by removing the build actions "Run" and "Archive" from the unit test target in the shared scheme.

This is the default configuration as of, at least, Xcode 7.1.1