### PR TITLE
Add an ability to copy the value from Observable without having to access it first

### DIFF
--- a/Observable-Swift/Protocols.swift
+++ b/Observable-Swift/Protocols.swift
@@ -71,7 +71,7 @@ public protocol OwnableObservable: AnyObservable {
 
 }
 
-// observable <- value
+// (observable <- value) or (observable.value <- observable.value)
 infix operator <-
 
 // value = observable^
@@ -115,6 +115,11 @@ public func += <T> (event: EventReference<ValueChange<T>>, handler: @escaping (T
 @discardableResult
 public func += <T> (event: EventReference<ValueChange<T>>, handler: @escaping (T) -> ()) -> EventSubscription<ValueChange<T>> {
     return event.add({ handler($0.newValue) })
+}
+
+// for observable values on observable values
+public func <- <T : WritableObservable & UnownableObservable> (x: inout T, y: T) {
+    x.value = y.value
 }
 
 // for observable values on variables

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ x.afterChange += { println("Changed x from \($0) to \($1)") }
 // change the value, prints "Changed x from 0 to 42"
 x <- 42
 // alternativelyL x ^= 42, without operators: x.value = 42
+
+
+var y = Observable(0)
+
+// Copy the value from one observable to another one, prints "Changed x from 42 to 0"
+x <- y
 ```
 
 You can, of course, have observable properties in a `class` or a `struct`:


### PR DESCRIPTION
Currently when copying values (let's say between models), we always need to access them.

Example:
```swift
model.name.value = diffModel.name.value
model.name <- diffModel.name.value

// or shorthand
model.name <- diffModel.name^
```

The improvement allow use to do this:
```swift
model.name <- diffModel.name
```

There is no need to access the value of the Observable and since we use `<-` operator this action seems to be also pretty clear (unlike `=`).