### PR TITLE
Fix warnings when compiling with Xcode 9 / Swift 3.2 & 4

### DIFF
--- a/Observable-Swift/ObservableChainingProxy.swift
+++ b/Observable-Swift/ObservableChainingProxy.swift
@@ -117,10 +117,10 @@ public func chain<O: AnyObservable>(_ o: O) -> ObservableChainingBase<O> {
     return ObservableChainingBase(base: o)
 }
 
-public func / <O1: AnyObservable, O2: AnyObservable, O3: AnyObservable> (o: ObservableChainingProxy<O1, O2>, f: @escaping (O2.ValueType) -> O3?) -> ObservableChainingProxy<ObservableChainingProxy<O1, O2>, O3> {
+public func / <O1, O2, O3> (o: ObservableChainingProxy<O1, O2>, f: @escaping (O2.ValueType) -> O3?) -> ObservableChainingProxy<ObservableChainingProxy<O1, O2>, O3> {
     return o.to(path: f)
 }
 
-public func / <O1: AnyObservable, O2: AnyObservable> (o: O1, f: @escaping (O1.ValueType) -> O2?) -> ObservableChainingProxy<O1, O2> {
+public func / <O1, O2> (o: O1, f: @escaping (O1.ValueType) -> O2?) -> ObservableChainingProxy<O1, O2> {
     return ObservableChainingProxy(base: o, path: f)
 }

--- a/Observable-Swift/TupleObservable.swift
+++ b/Observable-Swift/TupleObservable.swift
@@ -11,7 +11,7 @@ public class PairObservable<O1: AnyObservable, O2: AnyObservable> : OwnableObser
     internal typealias T1 = O1.ValueType
     internal typealias T2 = O2.ValueType
     
-    public typealias ValueType = (T1, T2)
+    public typealias ValueType = (O1.ValueType, O2.ValueType)
     
     public private(set) var beforeChange = EventReference<ValueChange<(T1, T2)>>()
     public private(set) var afterChange = EventReference<ValueChange<(T1, T2)>>()
@@ -19,7 +19,7 @@ public class PairObservable<O1: AnyObservable, O2: AnyObservable> : OwnableObser
     internal var first : T1
     internal var second : T2
     
-    public var value : (T1, T2) { return (first, second) }
+    public var value : ValueType { return (first, second) }
     
     private let _base1 : O1
     private let _base2 : O2

--- a/Observable-Swift/TupleObservable.swift
+++ b/Observable-Swift/TupleObservable.swift
@@ -13,8 +13,8 @@ public class PairObservable<O1: AnyObservable, O2: AnyObservable> : OwnableObser
     
     public typealias ValueType = (O1.ValueType, O2.ValueType)
     
-    public private(set) var beforeChange = EventReference<ValueChange<(T1, T2)>>()
-    public private(set) var afterChange = EventReference<ValueChange<(T1, T2)>>()
+    public private(set) var beforeChange = EventReference<ValueChange<ValueType>>()
+    public private(set) var afterChange = EventReference<ValueChange<ValueType>>()
     
     internal var first : T1
     internal var second : T2


### PR DESCRIPTION
Fixed a couple compilation warnings that occurred under Xcode 9 (default warning settings) & Swift >= 3.2

I believe those were the issues referenced at https://github.com/slazyk/Observable-Swift/issues/36

- Redefined `public ValueType` as to not use `internal` types
- Redefined `value` as to use `ValueType`
- Removed conformance of `O1` `O2` and `O3` to `AnyObservable` as this was redundant with `ObservableChainingProxy` type requirements 

@slazyk Please take a look and submit your feedback
